### PR TITLE
Update gitlab-python.yml

### DIFF
--- a/GitLabCICD/gitlab-python.yml
+++ b/GitLabCICD/gitlab-python.yml
@@ -29,7 +29,7 @@ dependency_scanning:
 
   script:
     # Setting up node in a python environment
-    - curl -sL https://deb.nodesource.com/setup_10.x | bash -
+    - apt-get update -y
     - apt-get install nodejs npm -y
     # Install Snyk and snyk-to-html
     - npm install -g snyk


### PR DESCRIPTION
current yaml installs Node v10.x. The image `python:3.8` uses the latest Debian 12, which does not support Node v10.x.

Replaced `curl` of Node v10.x and replaced with `apt-get update -y` to download the latest from the debian repos. This will allow `apt-get install node` to install the latest nodejs. See docker output in comments.